### PR TITLE
Fix replica and permissions

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -100,7 +100,6 @@ services:
         condition: service_healthy
       elasticsetup:
         condition: service_completed_successfully
-  
 
   # elastic-stack
   elasticsetup:
@@ -209,7 +208,8 @@ services:
 
   es02:
     depends_on:
-      - es01
+      elasticsetup:
+        condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
     container_name: es02
     env_file:
@@ -239,7 +239,8 @@ services:
 
   es03:
     depends_on:
-      - es02
+      elasticsetup:
+        condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
     container_name: es03
     env_file:
@@ -269,7 +270,8 @@ services:
 
   es04:
     depends_on:
-      - es03
+      elasticsetup:
+        condition: service_healthy
     image: docker.elastic.co/elasticsearch/elasticsearch:8.19.0
     container_name: es04
     env_file:

--- a/docker-compose/elasticsearch/es01.yml
+++ b/docker-compose/elasticsearch/es01.yml
@@ -34,7 +34,7 @@ xpack.monitoring.collection.enabled: true
 bootstrap.memory_lock: false
 
 # Node specialization - Master Coordinator
-node.roles: ["master", "ml", "remote_cluster_client"]
+node.roles: ["master","data", "ingest", "ml", "remote_cluster_client"]
 node.attr.node_type: coordinator
 
 # Coordinator optimizations

--- a/docker-compose/elasticsearch/es02.yml
+++ b/docker-compose/elasticsearch/es02.yml
@@ -34,7 +34,7 @@ xpack.monitoring.collection.enabled: true
 bootstrap.memory_lock: false
 
 # Node specialization - Data Worker
-node.roles: ["data", "ingest", "remote_cluster_client"]
+node.roles: ["master", "data", "ingest", "remote_cluster_client"]
 node.attr.node_type: worker
 
 # Worker optimizations

--- a/docker-compose/elasticsearch/es03.yml
+++ b/docker-compose/elasticsearch/es03.yml
@@ -34,7 +34,7 @@ xpack.monitoring.collection.enabled: true
 bootstrap.memory_lock: false
 
 # Node specialization - Data Worker
-node.roles: ["data", "ingest", "remote_cluster_client"]
+node.roles: ["master","data", "ingest", "remote_cluster_client"]
 node.attr.node_type: worker
 
 # Worker optimizations

--- a/docker-compose/elasticsearch/es04.yml
+++ b/docker-compose/elasticsearch/es04.yml
@@ -1,5 +1,5 @@
 cluster.name: ${CLUSTER_NAME}
-node.name: es03
+node.name: es04
 
 # Network settings
 network.host: 0.0.0.0
@@ -13,13 +13,13 @@ cluster.initial_master_nodes: ["es01"]
 # Security settings
 xpack.security.enabled: true
 xpack.security.http.ssl.enabled: true
-xpack.security.http.ssl.key: certs/es03/es03.key
-xpack.security.http.ssl.certificate: certs/es03/es03.crt
+xpack.security.http.ssl.key: certs/es04/es04.key
+xpack.security.http.ssl.certificate: certs/es04/es04.crt
 xpack.security.http.ssl.certificate_authorities: certs/ca/ca.crt
 
 xpack.security.transport.ssl.enabled: true
-xpack.security.transport.ssl.key: certs/es03/es03.key
-xpack.security.transport.ssl.certificate: certs/es03/es03.crt
+xpack.security.transport.ssl.key: certs/es04/es04.key
+xpack.security.transport.ssl.certificate: certs/es04/es04.crt
 xpack.security.transport.ssl.certificate_authorities: certs/ca/ca.crt
 xpack.security.transport.ssl.verification_mode: certificate
 

--- a/docker-compose/env/api.env.example
+++ b/docker-compose/env/api.env.example
@@ -6,5 +6,9 @@ ELASTIC_URL=es01:9200
 # Default index name for logs
 INDEX_NAME=log-test
 
+# Elasticsearch index settings
+ELASTIC_INDEX_REPLICAS=1
+ELASTIC_INDEX_SHARDS=1
+
 # Deployment environment
 DEPLOYMENT=PROD

--- a/docker-compose/kibana/kibana.yml
+++ b/docker-compose/kibana/kibana.yml
@@ -4,7 +4,12 @@ server.host: 0.0.0.0
 server.port: 5601
 
 # Elasticsearch connection
-elasticsearch.hosts: ["https://es01:9200"]
+elasticsearch.hosts: [
+  "https://es01:9200",
+  "https://es02:9200",
+  "https://es03:9200",
+  "https://es04:9200"
+]
 elasticsearch.username: kibana_system
 elasticsearch.password: ${KIBANA_PASSWORD}
 elasticsearch.ssl.certificateAuthorities: ["config/certs/ca/ca.crt"]

--- a/log_sender/Dockerfile
+++ b/log_sender/Dockerfile
@@ -1,3 +1,6 @@
+RUN adduser -D appuser
+USER appuser
+
 FROM rust:trixie AS builder
 WORKDIR /usr/src/log_sender
 COPY . .

--- a/r-proxy-actix/log-forwarding-api/Dockerfile
+++ b/r-proxy-actix/log-forwarding-api/Dockerfile
@@ -1,3 +1,6 @@
+RUN adduser -D appuser
+USER appuser
+
 FROM rust:trixie AS builder
 WORKDIR /usr/src/log-forwarding-api
 COPY . .

--- a/r-proxy-actix/log-forwarding-api/src/main.rs
+++ b/r-proxy-actix/log-forwarding-api/src/main.rs
@@ -35,7 +35,6 @@ async fn send_log(
 /// Endpoint that returns the container name OR if not available a uuid generated on startup within crate::main.
 #[get("/whoareyou")]
 async fn who_are_you(data: web::Data<AppState>) -> ActixResult<HttpResponse> {
-    println!("Fuck you");
     Ok(HttpResponse::Ok().json(serde_json::json!(
         {
             "instance_id": env::var("HOSTNAME").unwrap_or_else(|_| data.host_id.to_string())

--- a/r-proxy-actix/nginx/Dockerfile
+++ b/r-proxy-actix/nginx/Dockerfile
@@ -1,3 +1,7 @@
+RUN adduser -D appuser
+USER appuserUN adduser -D appuser
+USER appuser
+
 FROM nginx:stable-alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/rust-logger/Dockerfile
+++ b/rust-logger/Dockerfile
@@ -6,6 +6,9 @@
 
 # Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
 
+RUN adduser -D appuser
+USER appuser
+
 ARG RUST_VERSION=1.88.0
 ARG APP_NAME=rust-logger
 


### PR DESCRIPTION
This pull request introduces several improvements to the Elasticsearch cluster configuration, enhances security and deployment best practices, and adds flexibility for index creation. The main changes include updating node roles for better cluster resilience, improving Docker Compose service dependencies for health checks, parameterizing index settings, and enforcing non-root user execution in Dockerfiles.

**Elasticsearch Cluster Configuration:**

* Updated `node.roles` in `es01.yml`, `es02.yml`, and `es03.yml` to include both `master`, `data`, and `ingest` roles, improving cluster resilience and failover capabilities. (`[[1]](diffhunk://#diff-01324580a0b0e5663e24d08bf04945c171e2789c297ed3324699eb535aaa4e44L37-R37)`, `[[2]](diffhunk://#diff-01c57e59bf5e3f34080124f5303e1b5dbe9960e3ab6b41ec8873d191451eda47L37-R37)`, `[[3]](diffhunk://#diff-48df949fec3444a9ed7f2902869896cb1aa23dfb6c6aaddace89f32fb848e441L37-R37)`)
* Corrected node name and certificate/key references in `es04.yml` to use `es04` instead of `es03`, ensuring proper identity and security settings for the fourth node. (`[[1]](diffhunk://#diff-467c91a355917897bb424dbd389362cf87f570f61270313bbb61574f16a2e0a5L2-R2)`, `[[2]](diffhunk://#diff-467c91a355917897bb424dbd389362cf87f570f61270313bbb61574f16a2e0a5L16-R22)`)

**Docker Compose Improvements:**

* Changed `depends_on` for `es02`, `es03`, and `es04` services to depend on the health of `elasticsetup`, ensuring Elasticsearch nodes only start when setup is healthy. (`[[1]](diffhunk://#diff-21796814c2204c04ba29b3834e57d5399c2ba04589de42b2be845cf6a0309b11L212-R212)`, `[[2]](diffhunk://#diff-21796814c2204c04ba29b3834e57d5399c2ba04589de42b2be845cf6a0309b11L242-R243)`, `[[3]](diffhunk://#diff-21796814c2204c04ba29b3834e57d5399c2ba04589de42b2be845cf6a0309b11L272-R274)`)
* Removed duplicate or misplaced `elasticsetup` definition in `docker-compose.yml`. (`[docker-compose/docker-compose.ymlL104](diffhunk://#diff-21796814c2204c04ba29b3834e57d5399c2ba04589de42b2be845cf6a0309b11L104)`)

**Index Creation Flexibility:**

* Added environment variables `ELASTIC_INDEX_REPLICAS` and `ELASTIC_INDEX_SHARDS` for configurable index settings, and updated the Rust API to use these values when creating indices. (`[[1]](diffhunk://#diff-455984d58220bb4d7a45662ba49e69735b476e67eb3c88ec39147941b3789d47R9-R12)`, `[[2]](diffhunk://#diff-9d0a98d5c9b4933230d7453c308febcba0dd0653ca89adbf8c6599fdd745b3ddR67-R77)`, `[[3]](diffhunk://#diff-9d0a98d5c9b4933230d7453c308febcba0dd0653ca89adbf8c6599fdd745b3ddR95-R98)`, `[[4]](diffhunk://#diff-9d0a98d5c9b4933230d7453c308febcba0dd0653ca89adbf8c6599fdd745b3ddL140-L145)`)

**Security and Best Practices:**

* Updated Dockerfiles for `log_sender`, `log-forwarding-api`, `nginx`, and `rust-logger` to run as a non-root user (`appuser`), improving container security. (`[[1]](diffhunk://#diff-df057fbbe2f70d035691464a72d8fa534eb53c2db3b1f5d926adea17c1aadeffR1-R3)`, `[[2]](diffhunk://#diff-4b21bc52514b3e0c10bd70d2b25046acb5fbd107a3780c4e2dcfd516ffe3e5f4R1-R3)`, `[[3]](diffhunk://#diff-427ba27b5c13b3c595c52e0cca93c63105a862e7e375987be69eb0ea5319e627R1-R4)`, `[[4]](diffhunk://#diff-959e15b64945d30617f6b56dc3962ca0a59d5c26a209db91b853280185cf435bR9-R11)`)

**Kibana Configuration:**

* Modified `kibana.yml` to connect to all four Elasticsearch nodes, improving monitoring and fault tolerance. (`[docker-compose/kibana/kibana.ymlL7-R12](diffhunk://#diff-b00cfc5c0f092e72e682e2daa14683ce73ea3cbfc46ebff5e9af8ce6f12b9769L7-R12)`)